### PR TITLE
add a legacy app middleware to pipeline

### DIFF
--- a/config/pipeline.php
+++ b/config/pipeline.php
@@ -17,6 +17,7 @@ use Mezzio\Router\Middleware\MethodNotAllowedMiddleware;
 use Mezzio\Router\Middleware\RouteMiddleware;
 use Mezzio\Session\SessionMiddleware;
 use Psr\Container\ContainerInterface;
+use App\Middleware\LegacyApplicationMiddleware;
 
 /**
  * Setup middleware pipeline:
@@ -74,6 +75,9 @@ return function (Application $app, MiddlewareFactory $factory, ContainerInterfac
     $app->pipe(UserMiddleware::class);
     // Register the dispatch middleware in the middleware pipeline
     $app->pipe(DispatchMiddleware::class);
+
+    // Middleware to load a legacy app with its own routing structure
+    $app->pipe(LegacyApplicationMiddleware::class);
 
     // At this point, if no Response is returned by any middleware, the
     // NotFoundHandler kicks in; alternately, you can provide other fallback

--- a/src/App/ConfigProvider.php
+++ b/src/App/ConfigProvider.php
@@ -19,6 +19,7 @@ use App\View\Helper\Flash;
 use App\View\Helper\GetRole;
 use App\View\Helper\IsGrantedFactory;
 use Laminas\ServiceManager\Factory\InvokableFactory;
+use App\Middleware\LegacyApplicationMiddleware;
 
 /**
  * The configuration provider for the App module
@@ -68,6 +69,7 @@ class ConfigProvider
                 HomePageHandler::class  => HomePageHandlerFactory::class,
                 PrgMiddleware::class    => InvokableFactory::class,
                 UserMiddleware::class   => UserMiddlewareFactory::class,
+                LegacyApplicationMiddleware::class => InvokableFactory::class
             ],
         ];
     }

--- a/src/App/Middleware/LegacyApplicationMiddleware.php
+++ b/src/App/Middleware/LegacyApplicationMiddleware.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types = 1);
+namespace App\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class LegacyApplicationMiddleware implements MiddlewareInterface
+{
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        /**
+         * This Middleware is a pathway to a legacy app and should not be triggered for valid mezzio routes
+         *
+         * Middleware is to serve as a connector between Mezzio front-end and a legacy app.
+         *
+         * Legacy app is loaded when no valid mezzio route is found to satisfy a request
+         * and before mezzio triggers a 404 error)
+         *
+         * This middleware skeleton will supply its own mechanism to load a legacy app
+         * where the legacy app will use its own routing structure
+         */
+        die("Error: legacy app middleware should not be triggered for a valid mezzio route");
+    }
+}


### PR DESCRIPTION
I have a use case where I need to load a legacy app to sit on top of
mezzio front-end, where the legacy app has its own routing structure.

Legacy app is to load when a route is called that is not familiar to
mezzio, and before mezzio issues a 404 error

This middleware acts as a skeleton to use when writing code to load
a legacy app with its own routing structure.

Mezzio app and non-mezzio legacy app should peacefully coexist this way
together, and this relies on mezzio app being able to authenticate
successfully without triggering a 404 error.